### PR TITLE
Use only 32 bits in BucketBitShift assignment

### DIFF
--- a/FastDictionaryTest/ByteList.fs
+++ b/FastDictionaryTest/ByteList.fs
@@ -85,7 +85,7 @@ type Dictionary<'Key, 'Value when 'Key : equality> (entries: seq<'Key * 'Value>)
     // Create the Buckets with some initial capacity
     let mutable buckets : Bucket<'Key, 'Value>[] = Array.create 4 Bucket.empty
     // BitShift necessary for mapping HashCode to BucketIdx using Fibonacci Hashing
-    let mutable bucketBitShift = 64 - (System.Numerics.BitOperations.TrailingZeroCount buckets.Length)
+    let mutable bucketBitShift = 32 - (System.Numerics.BitOperations.TrailingZeroCount buckets.Length)
     // Used for Wrap Around addition/subtraction of offsets
     let mutable wrapAroundMask = buckets.Length - 1
 

--- a/FastDictionaryTest/ByteListRobinHood.fs
+++ b/FastDictionaryTest/ByteListRobinHood.fs
@@ -357,7 +357,7 @@ type Dictionary<'Key, 'Value when 'Key : equality> (entries: seq<'Key * 'Value>)
 
             // Increase the size of the backing store
             buckets <- Array.create (buckets.Length <<< 1) Bucket.empty
-            bucketBitShift <- 64 - (BitOperations.TrailingZeroCount buckets.Length)
+            bucketBitShift <- 32 - (BitOperations.TrailingZeroCount buckets.Length)
             wrapAroundMask <- buckets.Length - 1
             count <- 0
 

--- a/FastDictionaryTest/ByteListRobinHoodInline.fs
+++ b/FastDictionaryTest/ByteListRobinHoodInline.fs
@@ -384,7 +384,7 @@ type Dictionary<'Key, 'Value when 'Key : equality> (entries: seq<'Key * 'Value>)
 
             // Increase the size of the backing store
             buckets <- Array.create (buckets.Length <<< 1) Bucket.empty
-            bucketBitShift <- 64 - (BitOperations.TrailingZeroCount buckets.Length)
+            bucketBitShift <- 32 - (BitOperations.TrailingZeroCount buckets.Length)
             wrapAroundMask <- buckets.Length - 1
             count <- 0
 

--- a/FastDictionaryTest/ByteListRobinHoodVec128.fs
+++ b/FastDictionaryTest/ByteListRobinHoodVec128.fs
@@ -314,7 +314,7 @@ type Dictionary<'Key, 'Value when 'Key : equality> (entries: seq<'Key * 'Value>)
 
             // Increase the size of the backing store
             buckets <- Array.create (buckets.Length <<< 1) Bucket.empty
-            bucketBitShift <- 64 - (BitOperations.TrailingZeroCount buckets.Length)
+            bucketBitShift <- 32 - (BitOperations.TrailingZeroCount buckets.Length)
             wrapAroundMask <- buckets.Length - 1
             count <- 0
 

--- a/FastDictionaryTest/CacheEquality.fs
+++ b/FastDictionaryTest/CacheEquality.fs
@@ -166,7 +166,7 @@ type Dictionary<'Key, 'Value when 'Key : equality> (entries: seq<'Key * 'Value>)
 
             // Increase the size of the backing store
             buckets <- Array.create (buckets.Length <<< 1) []
-            bucketBitShift <- 64 - (BitOperations.TrailingZeroCount buckets.Length)
+            bucketBitShift <- 32 - (BitOperations.TrailingZeroCount buckets.Length)
             count <- 0
 
             for bucket in oldBuckets do

--- a/FastDictionaryTest/FibonacciHashing.fs
+++ b/FastDictionaryTest/FibonacciHashing.fs
@@ -76,7 +76,7 @@ type Dictionary<'Key, 'Value when 'Key : equality> (entries: seq<'Key * 'Value>)
 
             // Increase the size of the backing store
             buckets <- Array.create (buckets.Length <<< 1) []
-            slotBitShift <- 64 - (System.Numerics.BitOperations.TrailingZeroCount buckets.Length)
+            slotBitShift <- 32 - (System.Numerics.BitOperations.TrailingZeroCount buckets.Length)
             count <- 0
 
             for bucket in oldBuckets do

--- a/FastDictionaryTest/LinearProbing.fs
+++ b/FastDictionaryTest/LinearProbing.fs
@@ -218,7 +218,7 @@ type Dictionary<'Key, 'Value when 'Key : equality> (entries: seq<'Key * 'Value>)
 
             // Increase the size of the backing store
             buckets <- Array.create (buckets.Length <<< 1) Bucket.empty
-            bucketBitShift <- 64 - (BitOperations.TrailingZeroCount buckets.Length)
+            bucketBitShift <- 32 - (BitOperations.TrailingZeroCount buckets.Length)
             count <- 0
 
             for bucket in oldBuckets do

--- a/FastDictionaryTest/RobinHood.fs
+++ b/FastDictionaryTest/RobinHood.fs
@@ -87,7 +87,7 @@ type Dictionary<'Key, 'Value when 'Key : equality> (entries: seq<'Key * 'Value>)
     // Create the Buckets with some initial capacity
     let mutable buckets : Bucket<'Key, 'Value>[] = Array.create 4 Bucket.empty
     // BitShift necessary for mapping HashCode to BucketIdx using Fibonacci Hashing
-    let mutable bucketBitShift = 64 - (System.Numerics.BitOperations.TrailingZeroCount buckets.Length)
+    let mutable bucketBitShift = 32 - (System.Numerics.BitOperations.TrailingZeroCount buckets.Length)
 
 
     let computeBucketIndex (hashCode: int) =

--- a/FastDictionaryTest/RobinHoodEviction.fs
+++ b/FastDictionaryTest/RobinHoodEviction.fs
@@ -259,7 +259,7 @@ type Dictionary<'Key, 'Value when 'Key : equality> (entries: seq<'Key * 'Value>)
 
             // Increase the size of the backing store
             buckets <- Array.create (buckets.Length <<< 1) Bucket.empty
-            bucketBitShift <- 64 - (BitOperations.TrailingZeroCount buckets.Length)
+            bucketBitShift <- 32 - (BitOperations.TrailingZeroCount buckets.Length)
             count <- 0
 
             for bucket in oldBuckets do


### PR DESCRIPTION
First of all thank you for your series on dictionaries, great content!

I just wanted to make the assignment during `resize` look similar to the initial `BucketBitShift` assignment. As first I was surprised that the shift by more than 32 bits is working, but this seems to be the standard behavior in .net.